### PR TITLE
Fix incorrect exit codes in helper scripts

### DIFF
--- a/node-source/contrib/devtools/optimize-pngs.py
+++ b/node-source/contrib/devtools/optimize-pngs.py
@@ -49,7 +49,7 @@ for folder in folders:
                         stderr=subprocess.STDOUT).rstrip('\n')
             except:
                 print "pngcrush is not installed, aborting..."
-                sys.exit(0)
+                sys.exit(1)
         
             #verify
             if "Not a PNG file" in subprocess.check_output([pngcrush, "-n", "-v", file_path], stderr=subprocess.STDOUT):

--- a/node-source/share/rpcauth/rpcauth.py
+++ b/node-source/share/rpcauth/rpcauth.py
@@ -12,7 +12,7 @@ import hmac
 
 if len(sys.argv) < 2:
     sys.stderr.write('Please include username as an argument.\n')
-    sys.exit(0)
+    sys.exit(1)
 
 username = sys.argv[1]
 


### PR DESCRIPTION
## Summary
- exit with status 1 when username is missing in `rpcauth.py`
- exit with status 1 when `pngcrush` is unavailable in `optimize-pngs.py`

## Testing
- `python node-source/share/rpcauth/rpcauth.py` (shows usage message and exits with nonzero status)


------
https://chatgpt.com/codex/tasks/task_e_684a15d69568832c9743b4b17b8cc785